### PR TITLE
Feature/migrate flask restplus to flask restx

### DIFF
--- a/mediaserverV1/app/webservice/blueprint.py
+++ b/mediaserverV1/app/webservice/blueprint.py
@@ -1,4 +1,4 @@
-from flask_restplus import Api
+from flask_restx import Api
 from flask import Blueprint
 
 from app.webservice.controllers.user_controller import api as user_ns

--- a/mediaserverV1/app/webservice/controllers/file_controller.py
+++ b/mediaserverV1/app/webservice/controllers/file_controller.py
@@ -1,5 +1,5 @@
 from flask import request
-from flask_restplus import Resource
+from flask_restx import Resource
 from injector import inject
 from app.webservice.dtos.meta_dto import MetaDto
 from app.webservice.dtos.file_dto import FileDto

--- a/mediaserverV1/app/webservice/controllers/user_controller.py
+++ b/mediaserverV1/app/webservice/controllers/user_controller.py
@@ -1,5 +1,5 @@
 from flask import request
-from flask_restplus import Resource
+from flask_restx import Resource
 from injector import inject
 
 from app.webservice.dtos.user_dto import UserDto

--- a/mediaserverV1/app/webservice/dtos/file_dto.py
+++ b/mediaserverV1/app/webservice/dtos/file_dto.py
@@ -1,4 +1,4 @@
-from flask_restplus import Namespace, fields
+from flask_restx import Namespace, fields
 from app.webservice.dtos.meta_dto import MetaDto
 
 

--- a/mediaserverV1/app/webservice/dtos/meta_dto.py
+++ b/mediaserverV1/app/webservice/dtos/meta_dto.py
@@ -1,4 +1,4 @@
-from flask_restplus import Namespace, fields
+from flask_restx import Namespace, fields
 
 
 class MetaDto:

--- a/mediaserverV1/app/webservice/dtos/user_dto.py
+++ b/mediaserverV1/app/webservice/dtos/user_dto.py
@@ -1,4 +1,4 @@
-from flask_restplus import Namespace, fields
+from flask_restx import Namespace, fields
 
 
 class UserDto:

--- a/mediaserverV1/requirements.txt
+++ b/mediaserverV1/requirements.txt
@@ -10,7 +10,7 @@ Flask-Bcrypt==0.7.1
 Flask-Cors==3.0.10
 Flask-Injector==0.12.3
 Flask-Migrate==2.7.0
-flask-restplus==0.13.0
+flask-restx==0.3.0
 Flask-Script==2.0.6
 Flask-SocketIO==5.0.1
 Flask-SQLAlchemy==2.5.1


### PR DESCRIPTION
The `Flask-RESTPlus` library / extension of `Flask` no longer supported _( or just neglected for further development )_, therefore, it was replaced with the community drive fork, with the `Flask-RESTX`.